### PR TITLE
Chri7325/4.10.0

### DIFF
--- a/README_esri.md
+++ b/README_esri.md
@@ -1,0 +1,36 @@
+
+# How to build for runtimecore
+
+Update the version of compilers, cmake, and ninja in the scripts.
+
+- OpenCV 4.8.1
+- llvm 17.0.1
+- CMake 3.27.6
+- Ninja 1.10.2
+- Xcode 14.3.1
+- Visual Studio toolchain version 14.37.32822
+- Windows SDK 10.0.19041.0
+
+## linux
+
+
+```bash
+$ cd esri
+$ bash build_opencv_linux.sh
+```
+
+## macos
+
+```bash
+$ cd esri
+$ bash build_opencv_macos.sh
+```
+
+## windows
+
+```bash
+$ cd esri
+$ bash build_opencv_windows.sh
+```
+
+Zip the 4.8.1 directory to opencv-4.8.1.zip

--- a/README_esri.md
+++ b/README_esri.md
@@ -3,34 +3,33 @@
 
 Update the version of compilers, cmake, and ninja in the scripts.
 
-- OpenCV 4.8.1
-- llvm 17.0.1
-- CMake 3.27.6
-- Ninja 1.10.2
-- Xcode 14.3.1
-- Visual Studio toolchain version 14.37.32822
+- OpenCV 4.10.0
+- llvm 19.1.2
+- CMake 3.29.2
+- Ninja 1.11.1
+- Xcode 15.2.0
+- Visual Studio toolchain version 14.38.33130
 - Windows SDK 10.0.19041.0
 
 ## linux
 
-
 ```bash
-$ cd esri
-$ bash build_opencv_linux.sh
+cd esri
+./build_opencv_linux.sh
 ```
 
 ## macos
 
 ```bash
-$ cd esri
-$ bash build_opencv_macos.sh
+cd esri
+./build_opencv_macos.sh
 ```
 
 ## windows
 
 ```bash
-$ cd esri
-$ bash build_opencv_windows.sh
+cd esri
+./build_opencv_windows.sh
 ```
 
-Zip the 4.8.1 directory to opencv-4.8.1.zip
+Copy the generated opencv zip file to the network shares

--- a/esri/.gitignore
+++ b/esri/.gitignore
@@ -1,0 +1,4 @@
+build
+build_*
+install
+opencv-*.zip

--- a/esri/build_opencv_linux.sh
+++ b/esri/build_opencv_linux.sh
@@ -1,0 +1,74 @@
+
+set -ex
+
+rm -rf build
+rm -rf install
+
+mkdir build
+cd build
+
+OPENCV_VERSION=4.8.1
+export CC="/usr/local/rtc/llvm/17.0.1/bin/clang"
+export CXX="/usr/local/rtc/llvm/17.0.1/bin/clang++"
+PATH="/usr/local/rtc/cmake/3.27.6/bin:/usr/local/rtc/ninja/1.10.2/bin:$PATH"
+
+cmake \
+  -GNinja \
+  -DCMAKE_SYSROOT=/usr/local/rtc/sysroot/redhat8.4/x86_64 \
+  -DCMAKE_C_COMPILER_TARGET=x86_64-unknown-linux-gnu \
+  -DCMAKE_CXX_COMPILER_TARGET=x86_64-unknown-linux-gnu \
+  -DCMAKE_C_FLAGS="-m64 -stdlib=libc++ -rtlib=compiler-rt" \
+  -DCMAKE_CXX_FLAGS="-m64 -stdlib=libc++ -rtlib=compiler-rt" \
+  -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++ -static-libstdc++ -fuse-ld=lld -rtlib=compiler-rt -ldl -pthread" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=../install/${OPENCV_VERSION}/x64 \
+  -DENABLE_THIN_LTO=TRUE \
+  -DOPENCV_PYTHON_SKIP_DETECTION=ON \
+  -DWITH_FFMPEG=OFF \
+  -DWITH_GTK=OFF \
+  -DWITH_OPENCL=OFF \
+  -DWITH_JPEG=OFF \
+  -DWITH_JASPER=OFF \
+  -DWITH_IPP=OFF \
+  -DWITH_OPENEXR=OFF \
+  -DWITH_OPENJPEG=OFF \
+  -DWITH_PNG=OFF \
+  -DWITH_PROTOBUF=OFF \
+  -DWITH_TIFF=OFF \
+  -DWITH_WEBP=OFF \
+  -DWITH_TBB=OFF \
+  -DWITH_OPENMP=OFF \
+  -DPARALLEL_ENABLE_PLUGINS=OFF \
+  -DBUILD_ZLIB=ON \
+  -DBUILD_opencv_apps=OFF \
+  -DBUILD_opencv_features2d=OFF \
+  -DBUILD_opencv_flann=OFF \
+  -DBUILD_opencv_core=ON \
+  -DBUILD_opencv_imgcodecs=OFF \
+  -DBUILD_opencv_imgproc=ON \
+  -DBUILD_opencv_apps=OFF \
+  -DBUILD_opencv_calib3d=OFF \
+  -DBUILD_opencv_dnn=OFF \
+  -DBUILD_opencv_features2d=OFF \
+  -DBUILD_opencv_flann=OFF \
+  -DBUILD_opencv_gapi=OFF \
+  -DBUILD_opencv_highgui=OFF \
+  -DBUILD_opencv_java_bindings_generator=OFF \
+  -DBUILD_opencv_js=OFF \
+  -DBUILD_opencv_js_bindings_generator=OFF \
+  -DBUILD_opencv_ml=OFF \
+  -DBUILD_opencv_objc_bindings_generator=OFF \
+  -DBUILD_opencv_objdetect=OFF \
+  -DBUILD_opencv_photo=OFF \
+  -DBUILD_opencv_python_bindings_generator=OFF \
+  -DBUILD_opencv_python_tests=OFF \
+  -DBUILD_opencv_stitching=OFF \
+  -DBUILD_opencv_ts=OFF \
+  -DBUILD_opencv_video=OFF \
+  -DBUILD_opencv_videoio=OFF \
+  -DBUILD_opencv_world=OFF \
+  ../..
+ninja -v install
+
+cd ../install
+zip -r ../opencv-${OPENCV_VERSION}.zip ${OPENCV_VERSION}

--- a/esri/build_opencv_linux.sh
+++ b/esri/build_opencv_linux.sh
@@ -3,16 +3,14 @@ set -ex
 
 rm -rf build
 rm -rf install
-
-mkdir build
-cd build
+rm -f opencv-*.zip
 
 OPENCV_VERSION=4.10.0
 export CC="/usr/local/rtc/llvm/19.1.2/bin/clang"
 export CXX="/usr/local/rtc/llvm/19.1.2/bin/clang++"
 PATH="/usr/local/rtc/cmake/3.29.2/bin:/usr/local/rtc/ninja/1.11.1/bin:$PATH"
 
-cmake \
+cmake -S .. -B build \
   -GNinja \
   -DCMAKE_SYSROOT=/usr/local/rtc/sysroot/redhat8.4/x86_64 \
   -DCMAKE_C_COMPILER_TARGET=x86_64-unknown-linux-gnu \
@@ -21,7 +19,7 @@ cmake \
   -DCMAKE_CXX_FLAGS="-m64 -stdlib=libc++ -rtlib=compiler-rt" \
   -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++ -static-libstdc++ -fuse-ld=lld -rtlib=compiler-rt -ldl -pthread" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=../install/${OPENCV_VERSION}/x64 \
+  -DCMAKE_INSTALL_PREFIX=install/${OPENCV_VERSION}/x64 \
   -DENABLE_THIN_LTO=TRUE \
   -DOPENCV_PYTHON_SKIP_DETECTION=ON \
   -DWITH_FFMPEG=OFF \
@@ -66,9 +64,8 @@ cmake \
   -DBUILD_opencv_ts=OFF \
   -DBUILD_opencv_video=OFF \
   -DBUILD_opencv_videoio=OFF \
-  -DBUILD_opencv_world=OFF \
-  ../..
-ninja -v install
+  -DBUILD_opencv_world=OFF
+cmake --build build -t install
 
-cd ../install
+cd install
 zip -r ../opencv-${OPENCV_VERSION}.zip ${OPENCV_VERSION}

--- a/esri/build_opencv_linux.sh
+++ b/esri/build_opencv_linux.sh
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env bash
 set -ex
 
 rm -rf build
@@ -7,10 +7,10 @@ rm -rf install
 mkdir build
 cd build
 
-OPENCV_VERSION=4.8.1
-export CC="/usr/local/rtc/llvm/17.0.1/bin/clang"
-export CXX="/usr/local/rtc/llvm/17.0.1/bin/clang++"
-PATH="/usr/local/rtc/cmake/3.27.6/bin:/usr/local/rtc/ninja/1.10.2/bin:$PATH"
+OPENCV_VERSION=4.10.0
+export CC="/usr/local/rtc/llvm/19.1.2/bin/clang"
+export CXX="/usr/local/rtc/llvm/19.1.2/bin/clang++"
+PATH="/usr/local/rtc/cmake/3.29.2/bin:/usr/local/rtc/ninja/1.11.1/bin:$PATH"
 
 cmake \
   -GNinja \

--- a/esri/build_opencv_linux.sh
+++ b/esri/build_opencv_linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-rm -rf build
+rm -rf build_arm64 build_x64
 rm -rf install
 rm -f opencv-*.zip
 
@@ -10,14 +10,71 @@ export CC="/usr/local/rtc/llvm/19.1.2/bin/clang"
 export CXX="/usr/local/rtc/llvm/19.1.2/bin/clang++"
 PATH="/usr/local/rtc/cmake/3.29.2/bin:/usr/local/rtc/ninja/1.11.1/bin:$PATH"
 
-cmake -S .. -B build \
+cmake -S .. -B build_arm64 \
+  -GNinja \
+  -DCMAKE_SYSROOT=/usr/local/rtc/sysroot/redhat8.4/aarch64 \
+  -DCMAKE_C_COMPILER_TARGET=aarch64-unknown-linux-gnu \
+  -DCMAKE_CXX_COMPILER_TARGET=aarch64-unknown-linux-gnu \
+  -DCMAKE_C_FLAGS="-stdlib=libc++ -fuse-ld=lld -rtlib=compiler-rt" \
+  -DCMAKE_CXX_FLAGS="-stdlib=libc++ -fuse-ld=lld -rtlib=compiler-rt" \
+  -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++ -static-libstdc++ -fuse-ld=lld -rtlib=compiler-rt -ldl -pthread" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=install/${OPENCV_VERSION}/arm64 \
+  -DENABLE_THIN_LTO=TRUE \
+  -DOPENCV_PYTHON_SKIP_DETECTION=ON \
+  -DWITH_FFMPEG=OFF \
+  -DWITH_GTK=OFF \
+  -DWITH_OPENCL=OFF \
+  -DWITH_JPEG=OFF \
+  -DWITH_JASPER=OFF \
+  -DWITH_IPP=OFF \
+  -DWITH_OPENEXR=OFF \
+  -DWITH_OPENJPEG=OFF \
+  -DWITH_PNG=OFF \
+  -DWITH_PROTOBUF=OFF \
+  -DWITH_TIFF=OFF \
+  -DWITH_WEBP=OFF \
+  -DWITH_TBB=OFF \
+  -DWITH_OPENMP=OFF \
+  -DPARALLEL_ENABLE_PLUGINS=OFF \
+  -DBUILD_ZLIB=ON \
+  -DBUILD_opencv_apps=OFF \
+  -DBUILD_opencv_features2d=OFF \
+  -DBUILD_opencv_flann=OFF \
+  -DBUILD_opencv_core=ON \
+  -DBUILD_opencv_imgcodecs=OFF \
+  -DBUILD_opencv_imgproc=ON \
+  -DBUILD_opencv_apps=OFF \
+  -DBUILD_opencv_calib3d=OFF \
+  -DBUILD_opencv_dnn=OFF \
+  -DBUILD_opencv_features2d=OFF \
+  -DBUILD_opencv_flann=OFF \
+  -DBUILD_opencv_gapi=OFF \
+  -DBUILD_opencv_highgui=OFF \
+  -DBUILD_opencv_java_bindings_generator=OFF \
+  -DBUILD_opencv_js=OFF \
+  -DBUILD_opencv_js_bindings_generator=OFF \
+  -DBUILD_opencv_ml=OFF \
+  -DBUILD_opencv_objc_bindings_generator=OFF \
+  -DBUILD_opencv_objdetect=OFF \
+  -DBUILD_opencv_photo=OFF \
+  -DBUILD_opencv_python_bindings_generator=OFF \
+  -DBUILD_opencv_python_tests=OFF \
+  -DBUILD_opencv_stitching=OFF \
+  -DBUILD_opencv_ts=OFF \
+  -DBUILD_opencv_video=OFF \
+  -DBUILD_opencv_videoio=OFF \
+  -DBUILD_opencv_world=OFF
+cmake --build build_arm64 -t install
+
+cmake -S .. -B build_x64 \
   -GNinja \
   -DCMAKE_SYSROOT=/usr/local/rtc/sysroot/redhat8.4/x86_64 \
   -DCMAKE_C_COMPILER_TARGET=x86_64-unknown-linux-gnu \
   -DCMAKE_CXX_COMPILER_TARGET=x86_64-unknown-linux-gnu \
-  -DCMAKE_C_FLAGS="-m64 -stdlib=libc++ -rtlib=compiler-rt" \
-  -DCMAKE_CXX_FLAGS="-m64 -stdlib=libc++ -rtlib=compiler-rt" \
-  -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++ -static-libstdc++ -fuse-ld=lld -rtlib=compiler-rt -ldl -pthread" \
+  -DCMAKE_C_FLAGS="-m64 -stdlib=libc++ -fuse-ld=lld -rtlib=compiler-rt" \
+  -DCMAKE_CXX_FLAGS="-m64 -stdlib=libc++ -fuse-ld=lld -rtlib=compiler-rt" \
+  -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++ -static-libstdc++ -rtlib=compiler-rt -ldl -pthread" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=install/${OPENCV_VERSION}/x64 \
   -DENABLE_THIN_LTO=TRUE \
@@ -65,7 +122,7 @@ cmake -S .. -B build \
   -DBUILD_opencv_video=OFF \
   -DBUILD_opencv_videoio=OFF \
   -DBUILD_opencv_world=OFF
-cmake --build build -t install
+cmake --build build_x64 -t install
 
 cd install
 zip -r ../opencv-${OPENCV_VERSION}.zip ${OPENCV_VERSION}

--- a/esri/build_opencv_macos.sh
+++ b/esri/build_opencv_macos.sh
@@ -1,0 +1,66 @@
+
+set -ex
+
+rm -rf build
+rm -rf install
+
+OPENCV_VERSION=4.8.1
+export DEVELOPER_DIR="/Applications/Xcode_14.3.1.app/Contents/Developer"
+export CC="/usr/bin/clang"
+export CXX="/usr/bin/clang++"
+PATH="/usr/local/rtc/cmake/3.27.6/bin:/usr/local/rtc/ninja/1.10.2/bin:$PATH"
+
+cmake -S .. -B build \
+  -GNinja \
+  -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=install/${OPENCV_VERSION}  \
+  -DOPENCV_PYTHON_SKIP_DETECTION=ON \
+  -DWITH_FFMPEG=OFF \
+  -DWITH_GTK=OFF \
+  -DWITH_OPENCL=OFF \
+  -DWITH_JPEG=OFF \
+  -DWITH_JASPER=OFF \
+  -DWITH_IPP=OFF \
+  -DWITH_OPENEXR=OFF \
+  -DWITH_OPENJPEG=OFF \
+  -DWITH_PNG=OFF \
+  -DWITH_PROTOBUF=OFF \
+  -DWITH_TIFF=OFF \
+  -DWITH_WEBP=OFF \
+  -DWITH_TBB=OFF \
+  -DWITH_OPENMP=OFF \
+  -DPARALLEL_ENABLE_PLUGINS=OFF \
+  -DBUILD_ZLIB=ON \
+  -DBUILD_opencv_apps=OFF \
+  -DBUILD_opencv_features2d=OFF \
+  -DBUILD_opencv_flann=OFF \
+  -DBUILD_opencv_core=ON \
+  -DBUILD_opencv_imgcodecs=OFF \
+  -DBUILD_opencv_imgproc=ON \
+  -DBUILD_opencv_apps=OFF \
+  -DBUILD_opencv_calib3d=OFF \
+  -DBUILD_opencv_dnn=OFF \
+  -DBUILD_opencv_features2d=OFF \
+  -DBUILD_opencv_flann=OFF \
+  -DBUILD_opencv_gapi=OFF \
+  -DBUILD_opencv_highgui=OFF \
+  -DBUILD_opencv_java_bindings_generator=OFF \
+  -DBUILD_opencv_js=OFF \
+  -DBUILD_opencv_js_bindings_generator=OFF \
+  -DBUILD_opencv_ml=OFF \
+  -DBUILD_opencv_objc_bindings_generator=OFF \
+  -DBUILD_opencv_objdetect=OFF \
+  -DBUILD_opencv_photo=OFF \
+  -DBUILD_opencv_python_bindings_generator=OFF \
+  -DBUILD_opencv_python_tests=OFF \
+  -DBUILD_opencv_stitching=OFF \
+  -DBUILD_opencv_ts=OFF \
+  -DBUILD_opencv_video=OFF \
+  -DBUILD_opencv_videoio=OFF \
+  -DBUILD_opencv_world=OFF
+cmake --build build -t install
+
+cd install
+zip -r ../opencv-${OPENCV_VERSION}.zip ${OPENCV_VERSION}

--- a/esri/build_opencv_macos.sh
+++ b/esri/build_opencv_macos.sh
@@ -3,6 +3,7 @@ set -ex
 
 rm -rf build
 rm -rf install
+rm -f opencv-*.zip
 
 OPENCV_VERSION=4.10.0
 export DEVELOPER_DIR="/Applications/Xcode_15.2.0.app/Contents/Developer"
@@ -16,6 +17,7 @@ cmake -S .. -B build \
   -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=install/${OPENCV_VERSION}  \
+  -DENABLE_THIN_LTO=TRUE \
   -DOPENCV_PYTHON_SKIP_DETECTION=ON \
   -DWITH_FFMPEG=OFF \
   -DWITH_GTK=OFF \

--- a/esri/build_opencv_macos.sh
+++ b/esri/build_opencv_macos.sh
@@ -1,14 +1,14 @@
-
+#!/usr/bin/env bash
 set -ex
 
 rm -rf build
 rm -rf install
 
-OPENCV_VERSION=4.8.1
-export DEVELOPER_DIR="/Applications/Xcode_14.3.1.app/Contents/Developer"
+OPENCV_VERSION=4.10.0
+export DEVELOPER_DIR="/Applications/Xcode_15.2.0.app/Contents/Developer"
 export CC="/usr/bin/clang"
 export CXX="/usr/bin/clang++"
-PATH="/usr/local/rtc/cmake/3.27.6/bin:/usr/local/rtc/ninja/1.10.2/bin:$PATH"
+PATH="/usr/local/rtc/cmake/3.29.2/bin:/usr/local/rtc/ninja/1.11.1/bin:$PATH"
 
 cmake -S .. -B build \
   -GNinja \

--- a/esri/build_opencv_windows.sh
+++ b/esri/build_opencv_windows.sh
@@ -1,0 +1,102 @@
+OPENCV_VERSION=4.8.1
+
+function cmake_configure
+{
+  cmake \
+    -G "Visual Studio 17 2022" \
+    -T "version=14.37.32822" \
+    -DCMAKE_SYSTEM_VERSION=10.0.19041.0 \
+    -DCMAKE_INSTALL_PREFIX=do_not_install_here \
+    -DOPENCV_PYTHON_SKIP_DETECTION=ON \
+    -DWITH_FFMPEG=OFF \
+    -DWITH_OPENCL=OFF \
+    -DWITH_JPEG=OFF \
+    -DWITH_JASPER=OFF \
+    -DWITH_IPP=OFF \
+    -DWITH_OPENEXR=OFF \
+    -DWITH_OPENJPEG=OFF \
+    -DWITH_PNG=OFF \
+    -DWITH_PROTOBUF=OFF \
+    -DWITH_TIFF=OFF \
+    -DWITH_WEBP=OFF \
+    -DWITH_TBB=OFF \
+    -DWITH_OPENMP=OFF \
+    -DPARALLEL_ENABLE_PLUGINS=OFF \
+    -DBUILD_ZLIB=ON \
+    -DBUILD_opencv_apps=OFF \
+    -DBUILD_opencv_features2d=OFF \
+    -DBUILD_opencv_flann=OFF \
+    -DBUILD_opencv_core=ON \
+    -DBUILD_opencv_imgcodecs=OFF \
+    -DBUILD_opencv_imgproc=ON \
+    -DBUILD_opencv_apps=OFF \
+    -DBUILD_opencv_calib3d=OFF \
+    -DBUILD_opencv_dnn=OFF \
+    -DBUILD_opencv_features2d=OFF \
+    -DBUILD_opencv_flann=OFF \
+    -DBUILD_opencv_gapi=OFF \
+    -DBUILD_opencv_highgui=OFF \
+    -DBUILD_opencv_java_bindings_generator=OFF \
+    -DBUILD_opencv_js=OFF \
+    -DBUILD_opencv_js_bindings_generator=OFF \
+    -DBUILD_opencv_ml=OFF \
+    -DBUILD_opencv_objc_bindings_generator=OFF \
+    -DBUILD_opencv_objdetect=OFF \
+    -DBUILD_opencv_photo=OFF \
+    -DBUILD_opencv_python_bindings_generator=OFF \
+    -DBUILD_opencv_python_tests=OFF \
+    -DBUILD_opencv_stitching=OFF \
+    -DBUILD_opencv_ts=OFF \
+    -DBUILD_opencv_video=OFF \
+    -DBUILD_opencv_videoio=OFF \
+    -DBUILD_opencv_world=OFF \
+    "$@"
+}
+
+set -ex
+
+rm -rf build
+
+mkdir build
+cd build
+
+rm -rf build_x64
+rm -rf install_x64
+
+cmake_configure -S ../.. -B build_x64 -A x64
+cmake --build build_x64 --config Debug
+cmake --build build_x64 --config Release
+cmake --install build_x64 --config Debug --prefix install_x64
+cmake --install build_x64 --config Release --prefix install_x64
+
+rm -rf build_x86
+rm -rf install_x86
+cmake_configure -S ../.. -B build_x86 \
+    -A Win32 \
+    -DCMAKE_SYSTEM_NAME=Windows \
+    -DCMAKE_SYSTEM_VERSION=10.0 \
+    -DCMAKE_SYSTEM_PROCESSOR=x86
+cmake --build build_x86 --config Debug
+cmake --build build_x86 --config Release
+cmake --install build_x86 --config Debug --prefix install_x86
+cmake --install build_x86 --config Release --prefix install_x86
+
+rm -rf build_arm64
+rm -rf install_arm64
+cmake_configure -S ../.. -B build_arm64 \
+    -A ARM64 \
+    -DCMAKE_SYSTEM_NAME=Windows \
+    -DCMAKE_SYSTEM_VERSION=10.0 \
+    -DCMAKE_SYSTEM_PROCESSOR=ARM64
+cmake --build build_arm64 --config Debug
+cmake --build build_arm64 --config Release
+cmake --install build_arm64 --config Debug --prefix install_arm64
+cmake --install build_arm64 --config Release --prefix install_arm64
+
+cd ..
+
+rm -rf ${OPENCV_VERSION}
+mkdir ${OPENCV_VERSION}
+cp -r build/install_x64/* ${OPENCV_VERSION}
+cp -r build/install_x86/x86 ${OPENCV_VERSION}/x86
+cp -r build/install_arm64/ARM64 ${OPENCV_VERSION}/ARM64

--- a/esri/build_opencv_windows.sh
+++ b/esri/build_opencv_windows.sh
@@ -1,10 +1,11 @@
-OPENCV_VERSION=4.8.1
+#!/usr/bin/env bash
+OPENCV_VERSION=4.10.0
 
 function cmake_configure
 {
   cmake \
     -G "Visual Studio 17 2022" \
-    -T "version=14.37.32822" \
+    -T "version=14.38.33130" \
     -DCMAKE_SYSTEM_VERSION=10.0.19041.0 \
     -DCMAKE_INSTALL_PREFIX=do_not_install_here \
     -DOPENCV_PYTHON_SKIP_DETECTION=ON \

--- a/esri/build_opencv_windows.sh
+++ b/esri/build_opencv_windows.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 OPENCV_VERSION=4.10.0
+PATH="C:/rtc/cmake/3.29.2/bin:$PATH"
 
 function cmake_configure
 {
@@ -95,9 +96,11 @@ cmake --install build_arm64 --config Debug --prefix install_arm64
 cmake --install build_arm64 --config Release --prefix install_arm64
 
 cd ..
+rm -rf install/${OPENCV_VERSION}
+mkdir -p install/${OPENCV_VERSION}
+cd install
+cp -r ../build/install_x64/* ${OPENCV_VERSION}/
+cp -r ../build/install_x86/x86 ${OPENCV_VERSION}/x86
+cp -r ../build/install_arm64/ARM64 ${OPENCV_VERSION}/ARM64
 
-rm -rf ${OPENCV_VERSION}
-mkdir ${OPENCV_VERSION}
-cp -r build/install_x64/* ${OPENCV_VERSION}
-cp -r build/install_x86/x86 ${OPENCV_VERSION}/x86
-cp -r build/install_arm64/ARM64 ${OPENCV_VERSION}/ARM64
+powershell.exe Compress-Archive ${OPENCV_VERSION} ../opencv-${OPENCV_VERSION}.zip

--- a/modules/core/src/parallel/registry_parallel.impl.hpp
+++ b/modules/core/src/parallel/registry_parallel.impl.hpp
@@ -93,7 +93,7 @@ protected:
         enabledBackends.resize(enabled);
         CV_LOG_DEBUG(NULL, "core(parallel): Available backends(" << enabled << "): " << dumpBackends());
         std::sort(enabledBackends.begin(), enabledBackends.end(), sortByPriority);
-        CV_LOG_INFO(NULL, "core(parallel): Enabled backends(" << enabled << ", sorted by priority): " << (enabledBackends.empty() ? std::string("N/A") : dumpBackends()));
+        //CV_LOG_INFO(NULL, "core(parallel): Enabled backends(" << enabled << ", sorted by priority): " << (enabledBackends.empty() ? std::string("N/A") : dumpBackends()));
     }
 
     static std::vector<std::string> tokenize_string(const std::string& input, char token)


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/4062

Upgrades opencv to 4.10.0. I couldn't do a clean merge due to the release tracks diverging so I cherry picked changes from a clean state and reset the runtimecore branch. I also added linux arm64 support to slowly get the infrastructure for that.
